### PR TITLE
overrides option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -94,6 +94,22 @@ gulp.task('copyNpmDependencies', function() {
 });
 ```
 
+- **overrides**: Object of overrides to use for a package. Format is packageName => array of paths. For use when alternate files are wanted or the vendor package.json is incorrect.
+
+```Javascript
+var mainNpmFiles = require('gulp-main-npm-files');
+
+// Copy dependencies to build/node_modules/
+gulp.task('copyNpmDependencies', function() {
+  gulp.src(mainNpmFiles({
+		overrides: {
+			select2:  ['./dist/js/select2.full.js', './dist/css/select2.css']
+		}
+	}), { base:'./' })
+    .pipe(gulp.dest('./build'));
+});
+```
+
 ## Comments
 Don't hesitate to send me any recommendations, suggestions about this project. I really want to have some returns about does it work well, does it match user expectation, etc.
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,13 @@ module.exports = function(options) {
   keys = [];
 
   for (var key in packages.dependencies) {
+    if(options.overrides && options.overrides.hasOwnProperty(key)) {
+      options.overrides[key].forEach(function(override) {
+        keys.push(path.join(options.nodeModulesPath, key, override));
+      }, this);
+    } else {
     keys.push(getMainFile(options.nodeModulesPath + "/" + key));
+    }
   }
 
   if (options.devDependencies) {


### PR DESCRIPTION
Adds a new option - "overrides" that is an object used like a hash table.  The "key" of the hash table is the package name and thus the folder name under node_modules. The "value" of the hash table is an array of file paths to add to the result set rather than the main file.  The path is expected to be relative within the node package sub-directory (as if the present working directory is /node_modules/packageName/).  Kind of  modeled after main-bower-files overrides, but took one level of object out of the mix.  I kind of need this functionality to use this in my build process, hope the implementation is Ok, let me know if you would like changes or your thoughts.  Thanks for the great work.